### PR TITLE
Add missing 'after attribute name' state

### DIFF
--- a/lib/simple-html-tokenizer.js
+++ b/lib/simple-html-tokenizer.js
@@ -217,6 +217,20 @@ Tokenizer.prototype = {
       }
     },
 
+    afterAttributeName: function(char) {
+      if (isSpace(char)) {
+        return;
+      } else if (char === "/") {
+        this.state = 'selfClosingStartTag';
+      } else if (char === "=") {
+        this.state = 'beforeAttributeValue';
+      } else if (char === ">") {
+        return this.emitToken();
+      } else {
+        this.attribute(char);
+      }
+    },
+
     beforeAttributeValue: function(char) {
       if (isSpace(char)) {
         return;

--- a/tests/tokenizer-tests.js
+++ b/tests/tokenizer-tests.js
@@ -51,6 +51,11 @@ test("A tag with unquoted attribute", function() {
   equalToken(tokens, new HTML5Tokenizer.StartTag("div", [["id", "foo"]]));
 });
 
+test("A tag with a nonterminal, valueless attribute", function() {
+  var tokens = HTML5Tokenizer.tokenize('<div disabled id=foo>');
+  equalToken(tokens, new HTML5Tokenizer.StartTag("div", [["disabled", null], ["id", "foo"]]));
+});
+
 test("A tag with multiple attributes", function() {
   var tokens = HTML5Tokenizer.tokenize('<div id=foo class="bar baz" href=\'bat\'>');
   equalToken(tokens, new HTML5Tokenizer.StartTag("div", [["id", "foo"], ["class", "bar baz"], ["href", "bat"]]));


### PR DESCRIPTION
Previously, attempts to tokenize `<div disabled id="foo">` would fail.

/cc @wycats @kselden @ebryn, not sure who actually looks here ^_^
