### PR TITLE
Replace carriage returns with line feeds

### DIFF
--- a/lib/simple-html-tokenizer.js
+++ b/lib/simple-html-tokenizer.js
@@ -16,8 +16,12 @@ function isAlpha(char) {
   return (/[A-Za-z]/).test(char);
 }
 
+function preprocessInput(input) {
+  return input.replace(/\r\n?/g, "\n");
+}
+
 function Tokenizer(input) {
-  this.input = input;
+  this.input = preprocessInput(input);
   this.char = 0;
   this.line = 1;
   this.column = 0;
@@ -44,7 +48,7 @@ Tokenizer.prototype = {
   },
 
   tokenizePart: function(string) {
-    this.input += string;
+    this.input += preprocessInput(string);
     var tokens = [], token;
 
     while (this.char < this.input.length) {

--- a/test/tests/tokenizer-tests.js
+++ b/test/tests/tokenizer-tests.js
@@ -106,6 +106,13 @@ test("Character references are expanded", function() {
   tokensEqual(tokens, new StartTag("div", [["title", '"Foo & Bar" < << < < ≧̸ &Borksnorlax; ≦̸']]), false, "in attributes");
 });
 
+QUnit.module("simple-html-tokenizer - preprocessing");
+
+test("Carriage returns are replaced with line feeds", function() {
+  var tokens = tokenize("\r\r\n\r\r\n\n");
+  tokensEqual(tokens, locInfo(new Chars("\n\n\n\n\n"), 2, 0, 6, 0), true);
+});
+
 QUnit.module("simple-html-tokenizer - location info");
 
 test("tokens: chars start-tag chars", function() {
@@ -125,12 +132,12 @@ test("tokens: start-tag start-tag", function() {
   ], true);
 });
 
-test("tokens: chars \\n start-tag chars \\r\\n tag", function() {
-  var tokens = tokenize("chars\n<div>chars\r\n<div>");
+test("tokens: chars start-tag chars start-tag", function() {
+  var tokens = tokenize("chars\n<div>chars\n<div>");
   tokensEqual(tokens, [
     locInfo(new Chars("chars\n"), 1, 1, 2, 0),
     locInfo(new StartTag('div'), 2, 1, 2, 5),
-    locInfo(new Chars("chars\r\n"), 2, 6, 3, 0),
+    locInfo(new Chars("chars\n"), 2, 6, 3, 0),
     locInfo(new StartTag('div'), 3, 1, 3, 5)
   ], true);
 });


### PR DESCRIPTION
The tokenizer should never see carriage returns. See http://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html#preprocessing-the-input-stream

> U+000D CARRIAGE RETURN (CR) characters and U+000A LINE FEED (LF) characters are treated specially. All CR characters must be converted to LF characters, and any LF characters that immediately follow a CR character must be ignored. Thus, newlines in HTML DOMs are represented by LF characters, and there are never any CR characters in the input to the tokenization stage.
