### PR TITLE
Allow the tag name state to accept non-alpha chars

### DIFF
--- a/lib/simple-html-tokenizer.js
+++ b/lib/simple-html-tokenizer.js
@@ -1,20 +1,7 @@
 /*jshint boss:true*/
 
 import { namedCodepoints } from "simple-html-tokenizer/char-refs";
-
-var objectCreate = Object.create || function(obj) {
-  function F() {}
-  F.prototype = obj;
-  return new F();
-};
-
-function isSpace(char) {
-  return (/[\n\r\t ]/).test(char);
-}
-
-function isAlpha(char) {
-  return (/[A-Za-z]/).test(char);
-}
+import { objectCreate, isSpace, isAlpha, isUpper } from "simple-html-tokenizer/helpers";
 
 function preprocessInput(input) {
   return input.replace(/\r\n?/g, "\n");
@@ -69,8 +56,6 @@ Tokenizer.prototype = {
   },
 
   tag: function(Type, char) {
-    char = char.toLowerCase();
-
     var lastToken = this.token;
     this.token = new Type(char);
     this.state = 'tagName';
@@ -202,8 +187,8 @@ Tokenizer.prototype = {
         this.state = 'markupDeclaration';
       } else if (char === "/") {
         this.state = 'endTagOpen';
-      } else if (!isSpace(char)) {
-        return this.tag(StartTag, char);
+      } else if (isAlpha(char)) {
+        return this.tag(StartTag, char.toLowerCase());
       }
     },
 
@@ -265,10 +250,14 @@ Tokenizer.prototype = {
     tagName: function(char) {
       if (isSpace(char)) {
         this.state = 'beforeAttributeName';
-      } else if(/[A-Za-z0-9]/.test(char)) {
-        this.token.addToTagName(char);
+      } else if (char === "/") {
+        this.state = 'selfClosingStartTag';
       } else if (char === ">") {
         return this.emitToken();
+      } else if (isUpper(char)) {
+        this.token.addToTagName(char.toLowerCase());
+      } else {
+        this.token.addToTagName(char);
       }
     },
 
@@ -384,7 +373,7 @@ Tokenizer.prototype = {
 
     endTagOpen: function(char) {
       if (isAlpha(char)) {
-        this.tag(EndTag, char);
+        this.tag(EndTag, char.toLowerCase());
       }
     }
   }

--- a/lib/simple-html-tokenizer/helpers.js
+++ b/lib/simple-html-tokenizer/helpers.js
@@ -6,6 +6,24 @@ export function makeArray(object) {
   }
 }
 
+export var objectCreate = Object.create || function objectCreate(obj) {
+  function F() {}
+  F.prototype = obj;
+  return new F();
+};
+
+export function isSpace(char) {
+  return (/[\t\n\f ]/).test(char);
+}
+
+export function isAlpha(char) {
+  return (/[A-Za-z]/).test(char);
+}
+
+export function isUpper(char) {
+  return (/[A-Z]/).test(char);
+}
+
 export function removeLocInfo(tokens) {
   for (var i = 0; i < tokens.length; i++) {
     var token = tokens[i];

--- a/test/tests/tokenizer-tests.js
+++ b/test/tests/tokenizer-tests.js
@@ -28,6 +28,16 @@ test("A simple closing tag with trailing spaces", function() {
   tokensEqual(tokens, new EndTag("div"));
 });
 
+test("A pair of hyphenated tags", function() {
+  var tokens = tokenize("<x-foo></x-foo>");
+  tokensEqual(tokens, [new StartTag("x-foo"), new EndTag("x-foo")]);
+});
+
+test("A pair of mixed-case tags", function() {
+  var tokens = tokenize("<TaBlE></TABle");
+  tokensEqual(tokens, [new StartTag("table"), new EndTag("table")]);
+});
+
 test("A tag with a single-quoted attribute", function() {
   var tokens = tokenize("<div id='foo'>");
   tokensEqual(tokens, new StartTag("div", [["id", "foo"]]));


### PR DESCRIPTION
...in accordance with the spec. Currently `<x-foo>` is read as `<xfoo>`.
