### PR TITLE
Drop case normalization from tags and attributes

### DIFF
--- a/lib/simple-html-tokenizer.js
+++ b/lib/simple-html-tokenizer.js
@@ -72,7 +72,7 @@ Tokenizer.prototype = {
   },
 
   addToAttributeName: function(char) {
-    this.token.addToAttributeName(char.toLowerCase());
+    this.token.addToAttributeName(char);
   },
 
   addToAttributeValue: function(char) {
@@ -254,8 +254,6 @@ Tokenizer.prototype = {
         this.state = 'selfClosingStartTag';
       } else if (char === ">") {
         return this.emitToken();
-      } else if (isUpper(char)) {
-        this.token.addToTagName(char.toLowerCase());
       } else {
         this.token.addToTagName(char);
       }

--- a/test/tests/tokenizer-tests.js
+++ b/test/tests/tokenizer-tests.js
@@ -33,11 +33,6 @@ test("A pair of hyphenated tags", function() {
   tokensEqual(tokens, [new StartTag("x-foo"), new EndTag("x-foo")]);
 });
 
-test("A pair of mixed-case tags", function() {
-  var tokens = tokenize("<TaBlE></TABle");
-  tokensEqual(tokens, [new StartTag("table"), new EndTag("table")]);
-});
-
 test("A tag with a single-quoted attribute", function() {
   var tokens = tokenize("<div id='foo'>");
   tokensEqual(tokens, new StartTag("div", [["id", "foo"]]));
@@ -61,6 +56,16 @@ test("A tag with a nonterminal, valueless attribute", function() {
 test("A tag with multiple attributes", function() {
   var tokens = tokenize('<div id=foo class="bar baz" href=\'bat\'>');
   tokensEqual(tokens, new StartTag("div", [["id", "foo"], ["class", "bar baz"], ["href", "bat"]]));
+});
+
+test("A tag with capitalization in attributes", function() {
+  var tokens = tokenize('<svg viewBox="0 0 0 0">');
+  tokensEqual(tokens, new StartTag("svg", [["viewBox", "0 0 0 0"]]));
+});
+
+test("A tag with capitalization in the tag", function() {
+  var tokens = tokenize('<linearGradient>');
+  tokensEqual(tokens, new StartTag("linearGradient", []));
 });
 
 test("A self-closing tag", function() {


### PR DESCRIPTION
We trust the user to use proper capitalization for element names and attributes. Most of the time this doesn't matter, except when htmlbars or another engine wants to generate DOM using the tokens. The odd capitalization rules (like the `viewBox` attribute name, or `linearGradient` tag name) must be permitted to pass through.

The alternative approach, requiring that downstream libraries re-normalize `viewbox` to `viewBox`, seems difficult to maintain practically. Trusting the user to do what is right is simpler.

This PR is required for a downstream PR in htmlbars related to SVG element support (https://github.com/tildeio/htmlbars/pull/41).

/cc @mmun
