### PR TITLE
Move token methods to tokenizer

### DIFF
--- a/lib/simple-html-tokenizer/tokenizer.js
+++ b/lib/simple-html-tokenizer/tokenizer.js
@@ -55,39 +55,50 @@ Tokenizer.prototype = {
     }
   },
 
-  tag: function(Type, char) {
+  createTag: function(Type, char) {
     var lastToken = this.token;
     this.token = new Type(char);
     this.state = 'tagName';
     return lastToken;
   },
 
+  addToTagName: function(char) {
+    this.token.tagName += char;
+  },
+
   selfClosing: function() {
     this.token.selfClosing = true;
   },
 
-  attribute: function(char) {
-    this.token.startAttribute(char);
+  createAttribute: function(char) {
+    this._currentAttribute = [char.toLowerCase(), "", null];
+    this.token.attributes.push(this._currentAttribute);
     this.state = 'attributeName';
   },
 
   addToAttributeName: function(char) {
-    this.token.addToAttributeName(char);
+    this._currentAttribute[0] += char;
   },
 
   markAttributeQuoted: function(value) {
-    this.token.markAttributeQuoted(value);
+    this._currentAttribute[2] = value;
   },
 
   finalizeAttributeValue: function() {
-    this.token.finalizeAttributeValue();
+    if (this._currentAttribute) {
+      if (this._currentAttribute[2] === null) {
+        this._currentAttribute[2] = false;
+      }
+      this._currentAttribute = undefined;
+    }
   },
 
   addToAttributeValue: function(char) {
-    this.token.addToAttributeValue(char);
+    this._currentAttribute[1] = this._currentAttribute[1] || "";
+    this._currentAttribute[1] += char;
   },
 
-  commentStart: function() {
+  createComment: function() {
     var lastToken = this.token;
     this.token = new Comment();
     this.state = 'commentStart';
@@ -95,7 +106,18 @@ Tokenizer.prototype = {
   },
 
   addToComment: function(char) {
-    this.token.addChar(char);
+    this.addChar(char);
+  },
+
+  addChar: function(char) {
+    this.token.chars += char;
+  },
+
+  finalizeToken: function() {
+    if (this.token.type === 'StartTag') {
+      this.finalizeAttributeValue();
+    }
+    return this.token;
   },
 
   emitData: function() {
@@ -108,7 +130,7 @@ Tokenizer.prototype = {
 
   emitToken: function() {
     this.addLocInfo();
-    var lastToken = this.token.finalize();
+    var lastToken = this.finalizeToken();
     this.token = null;
     this.state = 'data';
     return lastToken;
@@ -120,7 +142,7 @@ Tokenizer.prototype = {
       this.markFirst();
     }
 
-    this.token.addChar(char);
+    this.addChar(char);
   },
 
   markFirst: function(line, column) {
@@ -152,7 +174,6 @@ Tokenizer.prototype = {
       } else {
         this.column++;
       }
-      // console.log(this.state, char);
       return this.states[this.state].call(this, char);
     } else {
       this.addLocInfo(this.line, this.column);
@@ -179,14 +200,14 @@ Tokenizer.prototype = {
       } else if (char === "/") {
         this.state = 'endTagOpen';
       } else if (isAlpha(char)) {
-        return this.tag(StartTag, char.toLowerCase());
+        return this.createTag(StartTag, char.toLowerCase());
       }
     },
 
     markupDeclaration: function(char) {
       if (char === "-" && this.input.charAt(this.char) === "-") {
         this.char++;
-        this.commentStart();
+        this.createComment();
       }
     },
 
@@ -246,7 +267,7 @@ Tokenizer.prototype = {
       } else if (char === ">") {
         return this.emitToken();
       } else {
-        this.token.addToTagName(char);
+        this.addToTagName(char);
       }
     },
 
@@ -258,7 +279,7 @@ Tokenizer.prototype = {
       } else if (char === ">") {
         return this.emitToken();
       } else {
-        this.attribute(char);
+        this.createAttribute(char);
       }
     },
 
@@ -287,7 +308,7 @@ Tokenizer.prototype = {
         return this.emitToken();
       } else {
         this.finalizeAttributeValue();
-        this.attribute(char);
+        this.createAttribute(char);
       }
     },
 
@@ -369,7 +390,7 @@ Tokenizer.prototype = {
 
     endTagOpen: function(char) {
       if (isAlpha(char)) {
-        this.tag(EndTag, char.toLowerCase());
+        this.createTag(EndTag, char.toLowerCase());
       }
     }
   }

--- a/lib/simple-html-tokenizer/tokens.js
+++ b/lib/simple-html-tokenizer/tokens.js
@@ -3,81 +3,19 @@ export function StartTag(tagName, attributes, selfClosing) {
   this.tagName = tagName || '';
   this.attributes = attributes || [];
   this.selfClosing = selfClosing === true;
-  this._currentAttribute = undefined;
 }
-
-StartTag.prototype = {
-  addToTagName: function(char) {
-    this.tagName += char;
-  },
-
-  startAttribute: function(char) {
-    this._currentAttribute = [char.toLowerCase(), "", null];
-    this.attributes.push(this._currentAttribute);
-  },
-
-  addToAttributeName: function(char) {
-    this._currentAttribute[0] += char;
-  },
-
-  markAttributeQuoted: function(value) {
-    this._currentAttribute[2] = value;
-  },
-
-  addToAttributeValue: function(char) {
-    this._currentAttribute[1] = this._currentAttribute[1] || "";
-    this._currentAttribute[1] += char;
-  },
-
-  finalizeAttributeValue: function() {
-    if (this._currentAttribute) {
-      if (this._currentAttribute[2] === null) {
-        this._currentAttribute[2] = false;
-      }
-      this._currentAttribute = undefined;
-    }
-  },
-
-  finalize: function() {
-    this.finalizeAttributeValue();
-    return this;
-  }
-};
 
 export function EndTag(tagName) {
   this.type = 'EndTag';
   this.tagName = tagName || '';
 }
 
-EndTag.prototype = {
-  addToTagName: function(char) {
-    this.tagName += char;
-  },
-  finalize: function () {
-    return this;
-  }
-};
-
 export function Chars(chars) {
   this.type = 'Chars';
   this.chars = chars || "";
 }
 
-Chars.prototype = {
-  addChar: function(char) {
-    this.chars += char;
-  }
-};
-
 export function Comment(chars) {
   this.type = 'Comment';
   this.chars = chars || '';
 }
-
-Comment.prototype = {
-  addChar: function(char) {
-    this.chars += char;
-  },
-
-  finalize: function() { return this; }
-};

--- a/test/generation-tests.js
+++ b/test/generation-tests.js
@@ -4,7 +4,7 @@ QUnit.test("A simple tag", function(assert) {
   assert.generates("<div>", "<div>");
 });
 
-QUnit.test("A simple tag with spce", function(assert) {
+QUnit.test("A simple tag with space", function(assert) {
   assert.generates("<div  >", "<div>");
 });
 


### PR DESCRIPTION
Prompted by suggestion in https://github.com/tildeio/htmlbars/pull/198.   This just moves the methods and temporary state (`_currentAttribute`) to the tokenizer, so that tokens themselves contain just data.  Still using constructors for them since the end-result is the same, plus the unit tests use the constructors for building expected values.

Reduces duplication a bit as some of the methods were identical or nearly so across several token types.  EDIT: And I should say that this will require changes to htmlbars as well (some trivial, but the ones concerning `tokens.js` less so, since that is overriding and adding methods).  So not sure it entirely justifies the trouble.
