### PR TITLE
Fix the loc info for lines with comments.

### DIFF
--- a/lib/simple-html-tokenizer/evented-tokenizer.js
+++ b/lib/simple-html-tokenizer/evented-tokenizer.js
@@ -142,7 +142,7 @@ EventedTokenizer.prototype = {
       var char = this.consume();
 
       if (char === "-" && this.input.charAt(this.index) === "-") {
-        this.index++;
+        this.consume();
         this.state = 'commentStart';
         this.delegate.beginComment();
       }


### PR DESCRIPTION
Manually incrementing `this.index` does not properly handle `\n` or increment the relative `this.column`. This makes any tokens on that same line have incorrect location information (since they are now shifted off by one character).

The evented tokenizer has no tests currently, which I would like to circle back on and fix.  But gotta :ship:....