### PR TITLE
Fix location information for unquoted attributes.

### DIFF
--- a/lib/simple-html-tokenizer/evented-tokenizer.js
+++ b/lib/simple-html-tokenizer/evented-tokenizer.js
@@ -344,18 +344,22 @@ EventedTokenizer.prototype = {
     },
 
     attributeValueUnquoted: function() {
-      var char = this.consume();
+      var char = this.peek();
 
       if (isSpace(char)) {
         this.delegate.finishAttributeValue();
+        this.consume();
         this.state = 'beforeAttributeName';
       } else if (char === "&") {
+        this.consume();
         this.delegate.appendToAttributeValue(this.consumeCharRef(">") || "&");
       } else if (char === ">") {
         this.delegate.finishAttributeValue();
+        this.consume();
         this.delegate.finishTag();
         this.state = 'beforeData';
       } else {
+        this.consume();
         this.delegate.appendToAttributeValue(char);
       }
     },


### PR DESCRIPTION
When an unquoted attribute is parsed we were eagerly consuming the character.  This meant that when `finishAttributeValue` was called the `this.column` and `this.line` have been incremented to include the next character.

This changes unquoted attributes to peek first, then consume when a given value is categorized. This is not an issue for quoted attributes because we are always consuming up to and including the final quote character.