### PR TITLE
Track attribute and attribute value start information.

### DIFF
--- a/lib/simple-html-tokenizer/evented-tokenizer.js
+++ b/lib/simple-html-tokenizer/evented-tokenizer.js
@@ -12,6 +12,8 @@ function EventedTokenizer(delegate, entityParser) {
   this.column = -1;
   this.tagLine = -1;
   this.tagColumn = -1;
+  this.currentAttributeStart = null;
+  this.currentAttributeValueStart = null;
 
   this.reset();
 }
@@ -27,6 +29,9 @@ EventedTokenizer.prototype = {
 
     this.tagLine = -1;
     this.tagColumn = -1;
+
+    this.currentAttributeStart = null;
+    this.currentAttributeValueStart = null;
 
     this.delegate.reset();
   },
@@ -99,6 +104,14 @@ EventedTokenizer.prototype = {
   markTagStart: function() {
     this.tagLine = this.line;
     this.tagColumn = this.column;
+  },
+
+  markAttributeStart: function() {
+    this.currentAttributeStart = { line: this.line, column: this.column };
+  },
+
+  markAttributeValueStart: function() {
+    this.currentAttributeValueStart = { line: this.line, column: this.column };
   },
 
   states: {
@@ -233,17 +246,21 @@ EventedTokenizer.prototype = {
     },
 
     beforeAttributeName: function() {
-      var char = this.consume();
+      var char = this.peek();
 
       if (isSpace(char)) {
+        this.consume();
         return;
       } else if (char === "/") {
         this.state = 'selfClosingStartTag';
+        this.consume();
       } else if (char === ">") {
+        this.consume();
         this.delegate.finishTag();
         this.state = 'beforeData';
       } else {
         this.state = 'attributeName';
+        this.markAttributeStart();
         this.delegate.beginAttribute();
         this.delegate.appendToAttributeName(char);
       }
@@ -255,12 +272,14 @@ EventedTokenizer.prototype = {
       if (isSpace(char)) {
         this.state = 'afterAttributeName';
       } else if (char === "/") {
+        this.markAttributeValueStart();
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
         this.state = 'selfClosingStartTag';
       } else if (char === "=") {
         this.state = 'beforeAttributeValue';
       } else if (char === ">") {
+        this.markAttributeValueStart();
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
         this.delegate.finishTag();
@@ -276,26 +295,31 @@ EventedTokenizer.prototype = {
       if (isSpace(char)) {
         return;
       } else if (char === "/") {
+        this.markAttributeValueStart();
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
         this.state = 'selfClosingStartTag';
       } else if (char === "=") {
         this.state = 'beforeAttributeValue';
       } else if (char === ">") {
+        this.markAttributeValueStart();
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
         this.delegate.finishTag();
         this.state = 'beforeData';
       } else {
+        this.markAttributeValueStart();
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
         this.state = 'attributeName';
+        this.markAttributeStart();
         this.delegate.beginAttribute();
         this.delegate.appendToAttributeName(char);
       }
     },
 
     beforeAttributeValue: function() {
+      this.markAttributeValueStart();
       var char = this.consume();
 
       if (isSpace(char)) {


### PR DESCRIPTION
This makes it much easier for downstream consumers to deal with attribute location information.

Currently, in HTMLBars and Glimmer we have to grab the start information manually during `beginAttribute`, but I would much prefer to simply track that information when we finish the attribute.

This is roughly inline with what is done for `tagLine` and `tagColumn`.

@mmun - r?