### PR TITLE
More location tweaks/fixes.

### DIFF
--- a/lib/simple-html-tokenizer/evented-tokenizer.js
+++ b/lib/simple-html-tokenizer/evented-tokenizer.js
@@ -255,45 +255,55 @@ EventedTokenizer.prototype = {
     },
 
     attributeName: function() {
-      var char = this.consume();
+      var char = this.peek();
 
       if (isSpace(char)) {
         this.state = 'afterAttributeName';
+        this.consume();
       } else if (char === "/") {
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
+        this.consume();
         this.state = 'selfClosingStartTag';
       } else if (char === "=") {
         this.state = 'beforeAttributeValue';
+        this.consume();
       } else if (char === ">") {
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
+        this.consume();
         this.delegate.finishTag();
         this.state = 'beforeData';
       } else {
+        this.consume();
         this.delegate.appendToAttributeName(char);
       }
     },
 
     afterAttributeName: function() {
-      var char = this.consume();
+      var char = this.peek();
 
       if (isSpace(char)) {
+        this.consume();
         return;
       } else if (char === "/") {
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
+        this.consume();
         this.state = 'selfClosingStartTag';
       } else if (char === "=") {
+        this.consume();
         this.state = 'beforeAttributeValue';
       } else if (char === ">") {
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
+        this.consume();
         this.delegate.finishTag();
         this.state = 'beforeData';
       } else {
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
+        this.consume();
         this.state = 'attributeName';
         this.delegate.beginAttribute();
         this.delegate.appendToAttributeName(char);
@@ -301,23 +311,28 @@ EventedTokenizer.prototype = {
     },
 
     beforeAttributeValue: function() {
-      var char = this.consume();
+      var char = this.peek();
 
       if (isSpace(char)) {
+        this.consume();
       } else if (char === '"') {
         this.state = 'attributeValueDoubleQuoted';
         this.delegate.beginAttributeValue(true);
+        this.consume();
       } else if (char === "'") {
         this.state = 'attributeValueSingleQuoted';
         this.delegate.beginAttributeValue(true);
+        this.consume();
       } else if (char === ">") {
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
+        this.consume();
         this.delegate.finishTag();
         this.state = 'beforeData';
       } else {
         this.state = 'attributeValueUnquoted';
         this.delegate.beginAttributeValue(false);
+        this.consume();
         this.delegate.appendToAttributeValue(char);
       }
     },

--- a/lib/simple-html-tokenizer/evented-tokenizer.js
+++ b/lib/simple-html-tokenizer/evented-tokenizer.js
@@ -97,8 +97,13 @@ EventedTokenizer.prototype = {
   },
 
   markTagStart: function() {
+    // these properties to be removed in next major bump
     this.tagLine = this.line;
     this.tagColumn = this.column;
+
+    if (this.delegate.tagOpen) {
+      this.delegate.tagOpen();
+    }
   },
 
   states: {

--- a/lib/simple-html-tokenizer/evented-tokenizer.js
+++ b/lib/simple-html-tokenizer/evented-tokenizer.js
@@ -238,18 +238,22 @@ EventedTokenizer.prototype = {
     },
 
     beforeAttributeName: function() {
-      var char = this.consume();
+      var char = this.peek();
 
       if (isSpace(char)) {
+        this.consume();
         return;
       } else if (char === "/") {
         this.state = 'selfClosingStartTag';
+        this.consume();
       } else if (char === ">") {
+        this.consume();
         this.delegate.finishTag();
         this.state = 'beforeData';
       } else {
         this.state = 'attributeName';
         this.delegate.beginAttribute();
+        this.consume();
         this.delegate.appendToAttributeName(char);
       }
     },


### PR DESCRIPTION
* Ensure `beginAttribute` is called before the first char is consumed.
* Ensure `loc` includes quotes for `beginAttributeValue`.
* Add tagOpen hook.