### PR TITLE
Small fix in preprocessInput() to avoid errors

### DIFF
--- a/lib/simple-html-tokenizer/utils.js
+++ b/lib/simple-html-tokenizer/utils.js
@@ -11,5 +11,9 @@ export function isAlpha(char) {
 }
 
 export function preprocessInput(input) {
-  return input.replace(CRLF, "\n");
+  // Replace only if "input" var contain some data
+  return input
+    ? input.replace(CRLF, "\n")
+    : input
+  ;
 }


### PR DESCRIPTION
I use Riot.js library that uses this library. And while i try to render my HTML tags, Riot.js sometimes throws an error in this line of code. What about add this small fix?