### PR TITLE
Annotate output with syntax errors

### DIFF
--- a/src/evented-tokenizer.js
+++ b/src/evented-tokenizer.js
@@ -250,11 +250,15 @@ EventedTokenizer.prototype = {
         this.consume();
         this.delegate.finishTag();
         this.state = 'beforeData';
-      } else {
+      } else if (char === '=') {
+        this.delegate.reportSyntaxError("attribute name cannot start with equals sign");
         this.state = 'attributeName';
         this.delegate.beginAttribute();
         this.consume();
         this.delegate.appendToAttributeName(char);
+      } else {
+        this.state = 'attributeName';
+        this.delegate.beginAttribute();
       }
     },
 
@@ -278,6 +282,10 @@ EventedTokenizer.prototype = {
         this.consume();
         this.delegate.finishTag();
         this.state = 'beforeData';
+      } else if (char === '"' || char === "'" || char === '<') {
+        this.delegate.reportSyntaxError(char + " is not a valid character within attribute names");
+        this.consume();
+        this.delegate.appendToAttributeName(char);
       } else {
         this.consume();
         this.delegate.appendToAttributeName(char);

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -141,6 +141,10 @@ Tokenizer.prototype = {
   },
 
   finishAttributeValue: function() {
+  },
+
+  reportSyntaxError: function(message) {
+    this.token.syntaxError = message;
   }
 };
 

--- a/tests/tokenizer-tests.js
+++ b/tests/tokenizer-tests.js
@@ -82,6 +82,25 @@ QUnit.test("A tag with valueless attributes", function(assert) {
   ]);
 });
 
+QUnit.test("Missing attribute name", function(assert) {
+  var tokens = HTML5Tokenizer.tokenize('<div =foo>');
+  assert.deepEqual(tokens, [
+    withSyntaxError("attribute name cannot start with equals sign", startTag("div", [
+      ['=foo', "", false]
+    ]))
+  ]);
+
+});
+
+QUnit.test("Invalid character in attribute name", function(assert) {
+  var tokens = HTML5Tokenizer.tokenize('<div ">');
+  assert.deepEqual(tokens, [
+    withSyntaxError("\" is not a valid character within attribute names", startTag("div", [
+      ['"', "", false]
+    ]))
+  ]);
+});
+
 QUnit.test("A tag with multiple attributes", function(assert) {
   var tokens = HTML5Tokenizer.tokenize('<div id=foo class="bar baz" href=\'bat\'>');
   assert.deepEqual(tokens, [
@@ -310,4 +329,9 @@ function locInfo(token, startLine, startColumn, endLine, endColumn) {
   };
 
   return token;
+}
+
+function withSyntaxError(message, result) {
+  result.syntaxError = message;
+  return result;
 }


### PR DESCRIPTION
This begins to add support for reporting syntax errors that are defined in the HTML tokenization spec. The general strategy is to use the defined error recovery semantics, but annotate the resulting token with a `syntaxError` message.

This work was motivated by https://github.com/tildeio/glimmer/pull/362

A glimmer PR is also forthcoming that will expose these to users.