### PR TITLE
Add module field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/tildeio/simple-html-tokenizer.git"
   },
   "main": "dist/simple-html-tokenizer.js",
+  "module": "dist/es6/index.js",
   "jsnext:main": "dist/es6/index.js",
   "typings": "dist/es6/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This pull request seeks to add a `module` field to the `package.json`, to allow automatic detection and ES2015 module resolution by Webpack 2+ and Rollup:

- https://webpack.js.org/configuration/resolve/#resolve-mainfields
- https://github.com/rollup/rollup/wiki/pkg.module

It's possible to configure either to pick up the existing `jsnext:main`, but (a) it'd be nice to be picked up by default without additional configuration and (b) in my experience libraries which opt in to `jsnext:main` don't always [transpile](https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features), so requires _further_ configuration to apply Babel (and the right Babel configuration) to `node_modules`. Since it appears that the `dist/es6` is already transpiled save ES2015 modules (sorry, not very familiar with TypeScript nor Ember CLI), this should work fine as-is.