### PR TITLE
tokenize() options should be optional

### DIFF
--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -1,8 +1,8 @@
-import Tokenizer, { Token } from './tokenizer';
+import Tokenizer, { Token, TokenizerOptions } from './tokenizer';
 import EntityParser from './entity-parser';
 import namedCharRefs from './html5-named-char-refs';
 
-export default function tokenize(input, options): Token[] {
+export default function tokenize(input, options?: TokenizerOptions): Token[] {
   let tokenizer = new Tokenizer(new EntityParser(namedCharRefs), options);
   return tokenizer.tokenize(input);
 }


### PR DESCRIPTION
The tokenize() helper function takes a mandatory second argument of options that are passed on to the Tokenizer constructor. In the constructor, however, the options hash is optional, making the helper function more strict than the constructor it delegates to. This commit changes the function signature of tokenize() to make the options hash optional. (This is how it is being used from within Glimmer VM.) It also adds type checking to the options argument, which was implicit `any` before.