### PR TITLE
Newline following <pre> or <textarea> must be dropped

### DIFF
--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -189,6 +189,24 @@ QUnit.test('Character references are expanded', function(assert) {
   ]);
 });
 
+// https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+QUnit.test('A newline immediately following a <pre> tag is stripped', function(assert) {
+  let tokens = tokenize("<pre>\nhello</pre>");
+  assert.deepEqual(tokens, [startTag('pre'), chars('hello'), endTag('pre')]);
+});
+
+// https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+QUnit.test('A newline immediately following a <PRE> tag is stripped', function(assert) {
+  let tokens = tokenize("<PRE>\nhello</PRE>");
+  assert.deepEqual(tokens, [startTag('PRE'), chars('hello'), endTag('PRE')]);
+});
+
+// https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+QUnit.test('A newline immediately following a <textarea> tag is stripped', function(assert) {
+  let tokens = tokenize("<textarea>\nhello</textarea>");
+  assert.deepEqual(tokens, [startTag('textarea'), chars('hello'), endTag('textarea')]);
+});
+
 QUnit.module('simple-html-tokenizer - preprocessing');
 
 QUnit.test('Carriage returns are replaced with line feeds', function(assert) {


### PR DESCRIPTION
This implements a legacy detail from the HTML spec.

> A single newline may be placed immediately after the start tag of pre and textarea elements. This does not affect the processing of the element. The otherwise optional newline must be included if the element's contents themselves start with a newline (because otherwise the leading newline in the contents would be treated like the optional newline, and ignored).
>
> The following two pre blocks are equivalent:

```
<pre>Hello</pre>
<pre>
Hello</pre>
```

Without this change, Glimmer produces different output than the browser HTML parser, which means your `<pre>` content looks different in fastboot mode. 