### PR TITLE
Allow `@` to be the first char in a tag name.

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -157,7 +157,7 @@ export default class EventedTokenizer {
         this.transitionTo(TokenizerState.markupDeclarationOpen);
       } else if (char === '/') {
         this.transitionTo(TokenizerState.endTagOpen);
-      } else if (isAlpha(char)) {
+      } else if (char === '@' || isAlpha(char)) {
         this.transitionTo(TokenizerState.tagName);
         this.tagNameBuffer = '';
         this.delegate.beginStartTag();
@@ -448,7 +448,7 @@ export default class EventedTokenizer {
     endTagOpen() {
       let char = this.consume();
 
-      if (isAlpha(char)) {
+      if (char === '@' || isAlpha(char)) {
         this.transitionTo(TokenizerState.tagName);
         this.tagNameBuffer = '';
         this.delegate.beginEndTag();

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -207,6 +207,12 @@ QUnit.test('A newline immediately following a <textarea> tag is stripped', funct
   assert.deepEqual(tokens, [startTag('textarea'), chars('hello'), endTag('textarea')]);
 });
 
+// https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md#dynamic-invocations
+QUnit.test('An Emberish named arg invocation', function(assert) {
+  let tokens = tokenize('<@foo></@foo>');
+  assert.deepEqual(tokens, [startTag('@foo'), endTag('@foo')]);
+});
+
 QUnit.module('simple-html-tokenizer - preprocessing');
 
 QUnit.test('Carriage returns are replaced with line feeds', function(assert) {


### PR DESCRIPTION
This allows glimmer-vm to support the following dynamic component invocation (as proposed by the [angle bracket invocation RFC](https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md#dynamic-invocations)):

```html
<@foo></@foo>
```