### PR TITLE
Ensure tokenizer handles self closing from attributeValueUnquoted.

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -400,6 +400,9 @@ export default class EventedTokenizer {
         this.delegate.finishAttributeValue();
         this.consume();
         this.transitionTo(TokenizerState.beforeAttributeName);
+      } else if (char === '/') {
+        this.consume();
+        this.transitionTo(TokenizerState.selfClosingStartTag);
       } else if (char === '&') {
         this.consume();
         this.delegate.appendToAttributeValue(this.consumeCharRef() || '&');

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -134,6 +134,16 @@ QUnit.test(
   }
 );
 
+QUnit.test(
+  'A self-closing tag with an attribute with unquoted value without space before closing (regression)',
+  function(assert) {
+    let tokens = tokenize('<input data-foo=bar/>');
+    assert.deepEqual(tokens, [
+      startTag('input', [['data-foo', 'bar', false]], true)
+    ]);
+  }
+);
+
 QUnit.test('A tag with a / in the middle', function(assert) {
   let tokens = tokenize('<img / src="foo.png">');
   assert.deepEqual(tokens, [startTag('img', [['src', 'foo.png', true]])]);


### PR DESCRIPTION
Previously the following:

```html
<FooBar data-foo=someUnquotedThing/>
```

Would not properly detect that this is a self-closing element, and would eventually throw an error (due to unclosed element).

Addresses https://github.com/glimmerjs/glimmer-vm/issues/829 and https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill/issues/10.