### PR TITLE
Fix regression with unquoted attributes without space before self-closing tag.

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -401,6 +401,7 @@ export default class EventedTokenizer {
         this.consume();
         this.transitionTo(TokenizerState.beforeAttributeName);
       } else if (char === '/') {
+        this.delegate.finishAttributeValue();
         this.consume();
         this.transitionTo(TokenizerState.selfClosingStartTag);
       } else if (char === '&') {


### PR DESCRIPTION
The prior change (adding `'/'` support to `afterAttributeUnquoted`) missed an important step: you have to `this.delegate.finishAttributeValue()` before transitioning out of `afterAttributeUnquoted` state (into `selfClosingStartTag` state).

The tests added along with that change passed due to the test harness (and non-evented tokenizer) being implemented in a way that completely ignores `finishAttributeValue` hook.

This change fixes the regression and updates the non-evented tokenizer to more properly match the pattern implemented in glimmer-vm (where `finishAttributeValue` actually appends the attribute to the current element node).