### PR TITLE
Ensure attrs following valueless attrs start at the correct col.

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -333,9 +333,9 @@ export default class EventedTokenizer {
       } else {
         this.delegate.beginAttributeValue(false);
         this.delegate.finishAttributeValue();
-        this.consume();
         this.transitionTo(TokenizerState.attributeName);
         this.delegate.beginAttribute();
+        this.consume();
         this.delegate.appendToAttributeName(char);
       }
     },


### PR DESCRIPTION
Prior to this we would the next attribute with a location info that is _after_ where it actually starts.

The test harness currently does not support validating loc information for attributes, but a failing was submitted in https://github.com/glimmerjs/glimmer-vm/pull/849. I confirmed that before this change that test fails, and after it passes.