### PR TITLE
Treat <title>, <script>, and <style> contents as text

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -146,13 +146,14 @@ export default class EventedTokenizer {
 
     data() {
       let char = this.peek();
+      let tag = this.tagNameBuffer.toLowerCase();
 
       if (char === '<' && !this.isIgnoredEndTag()) {
         this.delegate.finishData();
         this.transitionTo(TokenizerState.tagOpen);
         this.markTagStart();
         this.consume();
-      } else if (char === '&') {
+      } else if (char === '&' && tag !== 'script' && tag !== 'style') {
         this.consume();
         this.delegate.appendToData(this.consumeCharRef() || '&');
       } else {

--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -117,9 +117,9 @@ export default class EventedTokenizer {
   private isIgnoredEndTag(): boolean {
     let tag = this.tagNameBuffer.toLowerCase();
 
-    return (tag === 'title' && this.input.substr(this.index, 8) !== '</title>') ||
-      (tag === 'style' && this.input.substr(this.index, 8) !== '</style>') ||
-      (tag === 'script' && this.input.substr(this.index, 9) !== '</script>');
+    return (tag === 'title' && this.input.substring(this.index, this.index + 8) !== '</title>') ||
+      (tag === 'style' && this.input.substring(this.index, this.index + 8) !== '</style>') ||
+      (tag === 'script' && this.input.substring(this.index, this.index + 9) !== '</script>');
   }
 
   states: { [k in TokenizerState]?: (this: EventedTokenizer) => void } = {

--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -114,11 +114,19 @@ export default class EventedTokenizer {
     this.delegate.appendToTagName(char);
   }
 
+  private isIgnoredEndTag(): boolean {
+    let tag = this.tagNameBuffer.toLowerCase();
+
+    return (tag === 'title' && this.input.substr(this.index, 8) !== '</title>') ||
+      (tag === 'style' && this.input.substr(this.index, 8) !== '</style>') ||
+      (tag === 'script' && this.input.substr(this.index, 9) !== '</script>');
+  }
+
   states: { [k in TokenizerState]?: (this: EventedTokenizer) => void } = {
     beforeData() {
       let char = this.peek();
 
-      if (char === '<') {
+      if (char === '<' && !this.isIgnoredEndTag()) {
         this.transitionTo(TokenizerState.tagOpen);
         this.markTagStart();
         this.consume();
@@ -139,7 +147,7 @@ export default class EventedTokenizer {
     data() {
       let char = this.peek();
 
-      if (char === '<') {
+      if (char === '<' && !this.isIgnoredEndTag()) {
         this.delegate.finishData();
         this.transitionTo(TokenizerState.tagOpen);
         this.markTagStart();

--- a/src/generated/tokenizer-states.ts
+++ b/src/generated/tokenizer-states.ts
@@ -12,6 +12,7 @@ export const enum TokenizerState {
   tagOpen = 'tagOpen',
   endTagOpen = 'endTagOpen',
   tagName = 'tagName',
+  endTagName = 'endTagName',
   rcdataLessThanSign = 'rcdataLessThanSign',
   rcdataEndTagOpen = 'rcdataEndTagOpen',
   rcdataEndTagName = 'rcdataEndTagName',

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -222,6 +222,38 @@ QUnit.test('A newline immediately following a <textarea> tag is stripped', funct
   assert.deepEqual(tokens, [startTag('textarea'), chars('hello'), endTag('textarea')]);
 });
 
+// https://html.spec.whatwg.org/multipage/semantics.html#the-title-element
+QUnit.test('The title element content is always text', function(assert) {
+  let tokens = tokenize("<title>&quot;hey <b>there</b><!-- comment --></title>");
+  assert.deepEqual(tokens, [startTag('title'), chars('"hey <b>there</b><!-- comment -->'), endTag('title')]);
+});
+
+// https://html.spec.whatwg.org/multipage/semantics.html#the-style-element
+QUnit.test('The style element content is always text', function(assert) {
+  let tokens = tokenize("<style>&quot;hey <b>there</b><!-- comment --></style>");
+  assert.deepEqual(tokens, [startTag('style'), chars('"hey <b>there</b><!-- comment -->'), endTag('style')]);
+});
+
+// https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+QUnit.test('The script element content restrictions', function(assert) {
+  let tokens = tokenize("<script>&quot;hey <b>there</b><!-- comment --></script>");
+  assert.deepEqual(tokens, [startTag('script'), chars('"hey <b>there</b><!-- comment -->'), endTag('script')]);
+});
+
+QUnit.test('Two following script tags', function(assert) {
+  let tokens = tokenize("<script><!-- comment --></script> <script>second</script>");
+
+  assert.deepEqual(tokens, [
+    startTag('script'),
+    chars('<!-- comment -->'),
+    endTag('script'),
+    chars(' '),
+    startTag('script'),
+    chars('second'),
+    endTag('script')
+  ]);
+});
+
 // https://github.com/emberjs/rfcs/blob/master/text/0311-angle-bracket-invocation.md#dynamic-invocations
 QUnit.test('An Emberish named arg invocation', function(assert) {
   let tokens = tokenize('<@foo></@foo>');

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -231,13 +231,13 @@ QUnit.test('The title element content is always text', function(assert) {
 // https://html.spec.whatwg.org/multipage/semantics.html#the-style-element
 QUnit.test('The style element content is always text', function(assert) {
   let tokens = tokenize("<style>&quot;hey <b>there</b><!-- comment --></style>");
-  assert.deepEqual(tokens, [startTag('style'), chars('"hey <b>there</b><!-- comment -->'), endTag('style')]);
+  assert.deepEqual(tokens, [startTag('style'), chars('&quot;hey <b>there</b><!-- comment -->'), endTag('style')]);
 });
 
 // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
 QUnit.test('The script element content restrictions', function(assert) {
   let tokens = tokenize("<script>&quot;hey <b>there</b><!-- comment --></script>");
-  assert.deepEqual(tokens, [startTag('script'), chars('"hey <b>there</b><!-- comment -->'), endTag('script')]);
+  assert.deepEqual(tokens, [startTag('script'), chars('&quot;hey <b>there</b><!-- comment -->'), endTag('script')]);
 });
 
 QUnit.test('Two following script tags', function(assert) {

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -205,6 +205,11 @@ QUnit.test('A newline immediately following a <pre> tag is stripped', function(a
   assert.deepEqual(tokens, [startTag('pre'), chars('hello'), endTag('pre')]);
 });
 
+QUnit.test('A newline immediately following a closing </pre> tag is not stripped', function(assert) {
+  let tokens = tokenize("\n<pre>\nhello</pre>\n");
+  assert.deepEqual(tokens, [chars('\n'), startTag('pre'), chars('hello'), endTag('pre'), chars('\n')]);
+});
+
 // https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 QUnit.test('A newline immediately following a <PRE> tag is stripped', function(assert) {
   let tokens = tokenize("<PRE>\nhello</PRE>");


### PR DESCRIPTION
Fixes #21 

This PR is one of the fixes that aim to improve <title>, <script>, and <style> support in Ember FastBoot (see: https://github.com/glimmerjs/glimmer-vm/issues/796#issuecomment-506818798)

cc: @rwjblue 