### PR TITLE
Add support for parsing `<!DOCTYPE html>`

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -196,7 +196,7 @@ export default class EventedTokenizer {
           this.consume();
           this.consume();
           this.transitionTo(TokenizerState.doctype);
-          this.delegate.beginDoctype();
+          if (this.delegate.beginDoctype) this.delegate.beginDoctype();
         }
       }
     },
@@ -216,7 +216,7 @@ export default class EventedTokenizer {
         return;
       } else {
         this.transitionTo(TokenizerState.doctypeName);
-        this.delegate.appendToDoctypeName(char.toLowerCase());
+        if (this.delegate.appendToDoctypeName) this.delegate.appendToDoctypeName(char.toLowerCase());
       }
     },
 
@@ -226,10 +226,10 @@ export default class EventedTokenizer {
       if (isSpace(char)) {
         this.transitionTo(TokenizerState.afterDoctypeName);
       } else if (char === '>') {
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       } else {
-        this.delegate.appendToDoctypeName(char.toLowerCase());
+        if (this.delegate.appendToDoctypeName) this.delegate.appendToDoctypeName(char.toLowerCase());
       }
     },
 
@@ -239,7 +239,7 @@ export default class EventedTokenizer {
       if (isSpace(char)) {
         return;
       } else if (char === '>') {
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       } else {
         let nextSixChars = char.toUpperCase() + this.input.substring(this.index, this.index + 5).toUpperCase();
@@ -278,7 +278,7 @@ export default class EventedTokenizer {
         this.consume();
       } else if (char === '>') {
         this.consume();
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       }
     },
@@ -289,10 +289,10 @@ export default class EventedTokenizer {
       if (char === '"') {
         this.transitionTo(TokenizerState.afterDoctypePublicIdentifier);
       } else if (char === '>') {
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       } else {
-        this.delegate.appendToDoctypePublicIdentifier(char);
+        if (this.delegate.appendToDoctypePublicIdentifier) this.delegate.appendToDoctypePublicIdentifier(char);
       }
     },
 
@@ -302,10 +302,10 @@ export default class EventedTokenizer {
       if (char === "'") {
         this.transitionTo(TokenizerState.afterDoctypePublicIdentifier);
       } else if (char === '>') {
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       } else {
-        this.delegate.appendToDoctypePublicIdentifier(char);
+        if (this.delegate.appendToDoctypePublicIdentifier) this.delegate.appendToDoctypePublicIdentifier(char);
       }
     },
 
@@ -315,7 +315,7 @@ export default class EventedTokenizer {
       if (isSpace(char)) {
         this.transitionTo(TokenizerState.betweenDoctypePublicAndSystemIdentifiers);
       } else if (char === '>') {
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       } else if (char === '"') {
         this.transitionTo(TokenizerState.doctypeSystemIdentifierDoubleQuoted);
@@ -330,7 +330,7 @@ export default class EventedTokenizer {
       if (isSpace(char)) {
         return;
       } else if (char === '>') {
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       } else if (char === '"') {
         this.transitionTo(TokenizerState.doctypeSystemIdentifierDoubleQuoted);
@@ -345,10 +345,10 @@ export default class EventedTokenizer {
       if (char === '"') {
         this.transitionTo(TokenizerState.afterDoctypeSystemIdentifier);
       } else if (char === '>') {
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       } else {
-        this.delegate.appendToDoctypeSystemIdentifier(char);
+        if (this.delegate.appendToDoctypeSystemIdentifier) this.delegate.appendToDoctypeSystemIdentifier(char);
       }
     },
 
@@ -358,10 +358,10 @@ export default class EventedTokenizer {
       if (char === "'") {
         this.transitionTo(TokenizerState.afterDoctypeSystemIdentifier);
       } else if (char === '>') {
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       } else {
-        this.delegate.appendToDoctypeSystemIdentifier(char);
+        if (this.delegate.appendToDoctypeSystemIdentifier) this.delegate.appendToDoctypeSystemIdentifier(char);
       }
     },
 
@@ -371,7 +371,7 @@ export default class EventedTokenizer {
       if (isSpace(char)) {
         return;
       } else if (char === '>') {
-        this.delegate.endDoctype();
+        if (this.delegate.endDoctype) this.delegate.endDoctype();
         this.transitionTo(TokenizerState.beforeData);
       }
     },

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -99,6 +99,41 @@ export default class Tokenizer implements TokenizerDelegate {
 
   // Data
 
+  beginDoctype() {
+    this.push({
+      type: TokenType.Doctype,
+      name: '',
+    });
+  }
+
+  appendToDoctypeName(char: string) {
+    this.current(TokenType.Doctype).name += char;
+  }
+
+  appendToDoctypePublicIdentifier(char: string) {
+    let doctype = this.current(TokenType.Doctype);
+
+    if (doctype.publicIdentifier === undefined) {
+      doctype.publicIdentifier = char;
+    } else {
+      doctype.publicIdentifier += char;
+    }
+  }
+
+  appendToDoctypeSystemIdentifier(char: string) {
+    let doctype = this.current(TokenType.Doctype);
+
+    if (doctype.systemIdentifier === undefined) {
+      doctype.systemIdentifier = char;
+    } else {
+      doctype.systemIdentifier += char;
+    }
+  }
+
+  endDoctype() {
+    this.addLocInfo();
+  }
+
   beginData() {
     this.push({
       type: TokenType.Chars,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,12 @@ export interface TokenBase<T extends TokenType> {
   loc?: Location;
 }
 
+export interface Doctype extends TokenBase<TokenType.Doctype> {
+  name: string;
+  publicIdentifier?: string;
+  systemIdentifier?: string;
+}
+
 export interface StartTag extends TokenBase<TokenType.StartTag> {
   tagName: string;
   attributes: Attribute[];
@@ -48,9 +54,10 @@ export interface Comment extends TokenBase<TokenType.Comment> {
   chars: string;
 }
 
-export type Token = StartTag | EndTag | Chars | Comment;
+export type Token = StartTag | EndTag | Chars | Comment | Doctype;
 
 export const enum TokenType {
+  Doctype = 'Doctype',
   StartTag = 'StartTag',
   EndTag = 'EndTag',
   Chars = 'Chars',
@@ -62,12 +69,19 @@ export interface TokenMap {
   EndTag: EndTag;
   Chars: Chars;
   Comment: Comment;
+  Doctype: Doctype;
 }
 
 export interface TokenizerDelegate {
   reset(): void;
   finishData(): void;
   tagOpen(): void;
+
+  beginDoctype(): void;
+  appendToDoctypeName(char: string): void;
+  appendToDoctypePublicIdentifier(char: string): void;
+  appendToDoctypeSystemIdentifier(char: string): void;
+  endDoctype(): void;
 
   beginData(): void;
   appendToData(char: string): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,11 +77,12 @@ export interface TokenizerDelegate {
   finishData(): void;
   tagOpen(): void;
 
-  beginDoctype(): void;
-  appendToDoctypeName(char: string): void;
-  appendToDoctypePublicIdentifier(char: string): void;
-  appendToDoctypeSystemIdentifier(char: string): void;
-  endDoctype(): void;
+  // TODO: make these non-optional in preparation for the next major version release
+  beginDoctype?(): void;
+  appendToDoctypeName?(char: string): void;
+  appendToDoctypePublicIdentifier?(char: string): void;
+  appendToDoctypeSystemIdentifier?(char: string): void;
+  endDoctype?(): void;
 
   beginData(): void;
   appendToData(char: string): void;

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -1,5 +1,8 @@
 import {
   tokenize,
+  EventedTokenizer,
+  TokenizerDelegate,
+  EntityParser,
   Doctype,
   StartTag,
   EndTag,
@@ -11,6 +14,130 @@ import {
 } from 'simple-html-tokenizer';
 
 QUnit.module('simple-html-tokenizer - tokenizer');
+
+QUnit.test('does not fail if delegate does not include doctype methods', function(assert) {
+  let steps: Array<string[]> = [];
+
+  class MissingDoctypeTokenizerDelegate implements TokenizerDelegate {
+    reset() {
+      steps.push(['reset']);
+    }
+    finishData() {
+      steps.push(['finishData']);
+    }
+    tagOpen() {
+      steps.push(['tagOpen']);
+    }
+
+    beginData() {
+      steps.push(['beginData']);
+    }
+
+    appendToData(char: string) {
+      steps.push(['appendToData', char]);
+    }
+
+    beginStartTag() {
+      steps.push(['beginStartTag']);
+    }
+    appendToTagName(char: string) {
+      steps.push(['appendToTagName', char]);
+    }
+
+    beginAttribute() {
+      steps.push(['beginAttribute']);
+    }
+    appendToAttributeName(char: string) {
+      steps.push(['appendToAttributeName', char]);
+    }
+    beginAttributeValue(quoted: boolean) {
+      steps.push(['beginAttributeValue', `${quoted}`]);
+    }
+
+    appendToAttributeValue(char: string) {
+      steps.push(['appendToAttributeValue', char]);
+    }
+    finishAttributeValue() {
+      steps.push(['finishAttributeValue']);
+    }
+
+    markTagAsSelfClosing() {
+      steps.push(['markTagAsSelfClosing']);
+    }
+
+    beginEndTag() {
+      steps.push(['beginEndTag']);
+    }
+    finishTag() {
+      steps.push(['finishTag']);
+    }
+
+    beginComment() {
+      steps.push(['beginComment']);
+    }
+    appendToCommentData(char: string) {
+      steps.push(['appendToCommentData', char]);
+    }
+    finishComment() {
+      steps.push(['finishComment']);
+    }
+
+    reportSyntaxError(error: string) {
+      steps.push(['reportSyntaxError', error]);
+    }
+  }
+
+  let delegate = new MissingDoctypeTokenizerDelegate();
+  let tokenizer = new EventedTokenizer(delegate, new EntityParser({}));
+
+  tokenizer.tokenize('\n<!-- comment here --><!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">\n<!-- comment here -->');
+
+  assert.deepEqual(steps, [
+    [ "reset" ],
+    [ "reset" ],
+    [ "beginData" ],
+    [ "appendToData", "\n" ],
+    [ "finishData" ],
+    [ "tagOpen" ],
+    [ "beginComment" ],
+    [ "appendToCommentData", " " ],
+    [ "appendToCommentData", "c" ],
+    [ "appendToCommentData", "o" ],
+    [ "appendToCommentData", "m" ],
+    [ "appendToCommentData", "m" ],
+    [ "appendToCommentData", "e" ],
+    [ "appendToCommentData", "n" ],
+    [ "appendToCommentData", "t" ],
+    [ "appendToCommentData", " " ],
+    [ "appendToCommentData", "h" ],
+    [ "appendToCommentData", "e" ],
+    [ "appendToCommentData", "r" ],
+    [ "appendToCommentData", "e" ],
+    [ "appendToCommentData", " " ],
+    [ "finishComment" ],
+    [ "tagOpen" ],
+    [ "beginData" ],
+    [ "appendToData", "\n" ],
+    [ "finishData" ],
+    [ "tagOpen" ],
+    [ "beginComment" ],
+    [ "appendToCommentData", " " ],
+    [ "appendToCommentData", "c" ],
+    [ "appendToCommentData", "o" ],
+    [ "appendToCommentData", "m" ],
+    [ "appendToCommentData", "m" ],
+    [ "appendToCommentData", "e" ],
+    [ "appendToCommentData", "n" ],
+    [ "appendToCommentData", "t" ],
+    [ "appendToCommentData", " " ],
+    [ "appendToCommentData", "h" ],
+    [ "appendToCommentData", "e" ],
+    [ "appendToCommentData", "r" ],
+    [ "appendToCommentData", "e" ],
+    [ "appendToCommentData", " " ],
+    [ "finishComment" ]
+  ]);
+});
 
 QUnit.test('Doctype', function(assert) {
   let tokens = tokenize('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">');


### PR DESCRIPTION
The [spec](https://html.spec.whatwg.org/multipage/syntax.html#the-doctype) says this about `<!DOCTYPE`:

> DOCTYPEs are required for legacy reasons. When omitted, browsers tend to
> use a different rendering mode that is incompatible with some
> specifications. Including the DOCTYPE in a document ensures that the
> browser makes a best-effort attempt at following the relevant
> specifications.

This fixes an issue where we would end up in an incorrect state when the `<!DOCTYPE` declaration was found (e.g. https://github.com/ember-template-lint/ember-template-lint/issues/719).

Addresses https://github.com/ember-template-lint/ember-template-lint/issues/719
Addresses https://github.com/stefanpenner/find-scripts-srcs-in-document/issues/1

---

The specific breaking changes here are that the delegate now **must** have the following new methods:

```ts
  beginDoctype(): void;
  appendToDoctypeName(char: string): void;
  appendToDoctypePublicIdentifier(char: string): void;
  appendToDoctypeSystemIdentifier(char: string): void;
  endDoctype(): void;
```

Closes https://github.com/tildeio/simple-html-tokenizer/issues/28.