### PR TITLE
Throw syntax errors for invalid EndTags

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -267,17 +267,17 @@ export default class EventedTokenizer {
       let char = this.consume();
 
       if (isSpace(char)) {
-        this.transitionTo(TokenizerState.beforeAttributeName);
-        this.tagNameBuffer = '';
+        this.delegate.reportSyntaxError('closing tag must only contain tagname');
       } else if (char === '/') {
-        this.transitionTo(TokenizerState.selfClosingStartTag);
-        this.tagNameBuffer = '';
+        this.delegate.reportSyntaxError('closing tag cannot be self-closing');
       } else if (char === '>') {
         this.delegate.finishTag();
         this.transitionTo(TokenizerState.beforeData);
         this.tagNameBuffer = '';
       } else {
-        this.appendToTagName(char);
+        if (!this.delegate.current().syntaxError) {
+          this.appendToTagName(char);
+        }
       }
     },
 
@@ -487,6 +487,10 @@ export default class EventedTokenizer {
         this.tagNameBuffer = '';
         this.delegate.beginEndTag();
         this.appendToTagName(char);
+      } else {
+        this.transitionTo(TokenizerState.endTagName);
+        this.delegate.beginEndTag();
+        this.delegate.reportSyntaxError('closing tag cannot contain whitespace before tagname');
       }
     }
   };

--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -266,7 +266,7 @@ export default class EventedTokenizer {
     endTagName() {
       let char = this.consume();
 
-      if (isSpace(char)) {
+      if (isSpace(char) && isAlpha(this.peek())) {
         this.delegate.reportSyntaxError('closing tag must only contain tagname');
       } else if (char === '/') {
         this.delegate.reportSyntaxError('closing tag cannot be self-closing');
@@ -275,7 +275,7 @@ export default class EventedTokenizer {
         this.transitionTo(TokenizerState.beforeData);
         this.tagNameBuffer = '';
       } else {
-        if (!this.delegate.current().syntaxError) {
+        if (!this.delegate.current().syntaxError && !isSpace(char)) {
           this.appendToTagName(char);
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface TokenMap {
 }
 
 export interface TokenizerDelegate {
+  current(): Token;
   reset(): void;
   finishData(): void;
   tagOpen(): void;

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -31,9 +31,51 @@ QUnit.test('A simple closing tag', function(assert) {
   assert.deepEqual(tokens, [endTag('div')]);
 });
 
-QUnit.test('A simple closing tag with trailing spaces', function(assert) {
+QUnit.test('A closing tag cannot containg trailing spaces', function(assert) {
   let tokens = tokenize('</div   \t\n>');
-  assert.deepEqual(tokens, [endTag('div')]);
+  let output = [withSyntaxError(
+    'closing tag must only contain tagname',
+    endTag('div')
+  )];
+  assert.deepEqual(tokens, output);
+});
+
+QUnit.test('A closing tag cannot containg leading spaces', function(assert) {
+  let tokens = tokenize('</ div>');
+  let output = [withSyntaxError(
+    'closing tag cannot contain whitespace before tagname',
+    endTag('')
+  )];
+
+  assert.deepEqual(tokens, output);
+});
+
+QUnit.test('A closing tag cannot contain an attribute', function(assert) {
+  let tokens = tokenize('</div foo="bar">');
+
+  assert.deepEqual(tokens, [withSyntaxError(
+    'closing tag must only contain tagname',
+    endTag('div')
+  )]);
+});
+
+QUnit.test('A closing tag cannot contain multiple attributes', function(assert) {
+  let tokens = tokenize('</div foo="bar" foo="baz">');
+  assert.deepEqual(tokens, [withSyntaxError(
+    'closing tag must only contain tagname',
+    endTag('div')
+  )]);
+});
+
+QUnit.test('A closing tag cannot be self-closing', function(assert) {
+  let tokens = tokenize('</div/>');
+
+  let output = [withSyntaxError(
+    'closing tag cannot be self-closing',
+    endTag('div')
+  )];
+
+  assert.deepEqual(tokens, output);
 });
 
 QUnit.test('A pair of hyphenated tags', function(assert) {

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -31,12 +31,10 @@ QUnit.test('A simple closing tag', function(assert) {
   assert.deepEqual(tokens, [endTag('div')]);
 });
 
-QUnit.test('A closing tag cannot containg trailing spaces', function(assert) {
+QUnit.test('A closing tag can containg trailing spaces', function(assert) {
   let tokens = tokenize('</div   \t\n>');
-  let output = [withSyntaxError(
-    'closing tag must only contain tagname',
-    endTag('div')
-  )];
+  let output = [endTag('div')];
+
   assert.deepEqual(tokens, output);
 });
 


### PR DESCRIPTION
This PR is in response to this comment PR https://github.com/glimmerjs/glimmer-vm/pull/982#discussion_r340068648.

Currently Simple HTML Tokenizer allows leading whitespace as well as attributes to be defined in End Tags. The comment linked above suggests that we throw syntax errors in these cases as they are ultimately invalid End Tags

The HTML Spec seems to be a bit inconsistent when it comes to attributes in End Tags, as the [12.1.2.2 End tags](https://html.spec.whatwg.org/multipage/syntax.html#end-tags) section says;

> ...
> 4. After the tag name, there may be one or more ASCII whitespace.
> 5. Finally, end tags must be closed by a U+003E GREATER-THAN SIGN character (>).

However [12.2.5.7 End tag open state](https://html.spec.whatwg.org/multipage/parsing.html#end-tag-open-state) says to enter the [12.2.5.8 Tag name state](https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state) when an the first ASCII Alpha character is encountered. The "tag name state" is not specific to End Tags, and allows for entering the "before attribute name state" and the "self-closing start tag state", both of which aren't really valid in End Tags.

--- 

This PR assumes that we want to prevent entering these invalid states and adds syntax errors in the following scenarios:
- Leading whitespace before the tagname in an EndTag. i.e `</ div>`
- Attributes after EndTag tagname. i.e `</div foo="bar">`
- Self closing EndTags. i.e `</div/>`