### PR TITLE
Only match `title`, `style`, `script` lowercase variants

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -115,7 +115,7 @@ export default class EventedTokenizer {
   }
 
   private isIgnoredEndTag(): boolean {
-    let tag = this.tagNameBuffer.toLowerCase();
+    let tag = this.tagNameBuffer;
 
     return (tag === 'title' && this.input.substring(this.index, this.index + 8) !== '</title>') ||
       (tag === 'style' && this.input.substring(this.index, this.index + 8) !== '</style>') ||
@@ -146,7 +146,7 @@ export default class EventedTokenizer {
 
     data() {
       let char = this.peek();
-      let tag = this.tagNameBuffer.toLowerCase();
+      let tag = this.tagNameBuffer;
 
       if (char === '<' && !this.isIgnoredEndTag()) {
         this.delegate.finishData();

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -231,7 +231,7 @@ QUnit.test('The title element content is always text', function(assert) {
 // https://github.com/emberjs/ember.js/issues/18530
 QUnit.test('Title element content is not text', function(assert) {
   let tokens = tokenize("<Title><!-- hello --></Title>");
-  assert.deepEqual(tokens, [startTag('title'), comment(' hello '), endTag('title')]);
+  assert.deepEqual(tokens, [startTag('Title'), comment(' hello '), endTag('Title')]);
 });
 
 // https://html.spec.whatwg.org/multipage/semantics.html#the-style-element

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -228,6 +228,12 @@ QUnit.test('The title element content is always text', function(assert) {
   assert.deepEqual(tokens, [startTag('title'), chars('"hey <b>there</b><!-- comment -->'), endTag('title')]);
 });
 
+// https://github.com/emberjs/ember.js/issues/18530
+QUnit.test('Title element content is not text', function(assert) {
+  let tokens = tokenize("<Title><!-- hello --></Title>");
+  assert.deepEqual(tokens, [startTag('title'), comment(' hello '), endTag('title')]);
+});
+
 // https://html.spec.whatwg.org/multipage/semantics.html#the-style-element
 QUnit.test('The style element content is always text', function(assert) {
   let tokens = tokenize("<style>&quot;hey <b>there</b><!-- comment --></style>");


### PR DESCRIPTION
This is a follow-up for https://github.com/tildeio/simple-html-tokenizer/pull/69, would fix https://github.com/glimmerjs/glimmer-vm/pull/1007

It implements this comment: https://github.com/emberjs/ember.js/issues/18530#issuecomment-548873013

Might also unblock https://github.com/prettier/prettier/pull/7245