### PR TITLE
Do not drop newlines after <TextArea> or <PRE>

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -132,7 +132,7 @@ export default class EventedTokenizer {
         this.consume();
       } else {
         if (char === '\n') {
-          let tag = this.tagNameBuffer.toLowerCase();
+          let tag = this.tagNameBuffer;
 
           if (tag === 'pre' || tag === 'textarea') {
             this.consume();

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -213,12 +213,12 @@ QUnit.test('A newline immediately following a closing </pre> tag is not stripped
 // https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 QUnit.test('A newline immediately following a <PRE> tag is stripped', function(assert) {
   let tokens = tokenize("<PRE>\nhello</PRE>");
-  assert.deepEqual(tokens, [startTag('PRE'), chars('hello'), endTag('PRE')]);
+  assert.deepEqual(tokens, [startTag('PRE'), chars('\nhello'), endTag('PRE')]);
 });
 
 QUnit.test('A newline immediately following a <Pre> tag is not stripped', function(assert) {
   let tokens = tokenize("<Pre>\nhello</Pre>");
-  assert.deepEqual(tokens, [startTag('Pre'), chars('\n'), chars('hello'), endTag('Pre')]);
+  assert.deepEqual(tokens, [startTag('Pre'), chars('\nhello'), endTag('Pre')]);
 });
 
 // https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
@@ -229,7 +229,7 @@ QUnit.test('A newline immediately following a <textarea> tag is stripped', funct
 
 QUnit.test('A newline immediately following a <Textarea> tag is not stripped', function(assert) {
   let tokens = tokenize("<Textarea>\nhello</Textarea>");
-  assert.deepEqual(tokens, [startTag('Textarea'), chars('\n'), chars('hello'), endTag('Textarea')]);
+  assert.deepEqual(tokens, [startTag('Textarea'), chars('\nhello'), endTag('Textarea')]);
 });
 
 // https://html.spec.whatwg.org/multipage/semantics.html#the-title-element

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -216,10 +216,20 @@ QUnit.test('A newline immediately following a <PRE> tag is stripped', function(a
   assert.deepEqual(tokens, [startTag('PRE'), chars('hello'), endTag('PRE')]);
 });
 
+QUnit.test('A newline immediately following a <Pre> tag is not stripped', function(assert) {
+  let tokens = tokenize("<Pre>\nhello</Pre>");
+  assert.deepEqual(tokens, [startTag('Pre'), chars('\n'), chars('hello'), endTag('Pre')]);
+});
+
 // https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 QUnit.test('A newline immediately following a <textarea> tag is stripped', function(assert) {
   let tokens = tokenize("<textarea>\nhello</textarea>");
   assert.deepEqual(tokens, [startTag('textarea'), chars('hello'), endTag('textarea')]);
+});
+
+QUnit.test('A newline immediately following a <Textarea> tag is not stripped', function(assert) {
+  let tokens = tokenize("<Textarea>\nhello</Textarea>");
+  assert.deepEqual(tokens, [startTag('Textarea'), chars('\n'), chars('hello'), endTag('Textarea')]);
 });
 
 // https://html.spec.whatwg.org/multipage/semantics.html#the-title-element


### PR DESCRIPTION
#59 applied [a detail from the html spec](https://github.com/tildeio/simple-html-tokenizer/pull/59#issue-183923917): 
> A single newline may be placed immediately after the start tag of pre and textarea elements. This does not affect the processing of the element.

As html is case insensitive to tag names, it was also applied to `<TextArea>` or `<PRE>`.

But... Angle bracket components have been introduced. And `<TextArea>` is now primarly a component, instead of a `<textarea>`.

This PR would adjust the html spec implementation to only lowercased `textarea` and `pre` tags.