### PR TITLE
Narrow #59 implementation to non selfClosing tags

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -11,6 +11,7 @@ export default class EventedTokenizer {
   private index = -1;
 
   private tagNameBuffer = '';
+  private selfClosingBuffer = false;
 
   constructor(
     private delegate: TokenizerDelegate,
@@ -134,7 +135,7 @@ export default class EventedTokenizer {
         if (char === '\n') {
           let tag = this.tagNameBuffer.toLowerCase();
 
-          if (tag === 'pre' || tag === 'textarea') {
+          if ((tag === 'pre' || tag === 'textarea') && !this.selfClosingBuffer) {
             this.consume();
           }
         }
@@ -468,8 +469,10 @@ export default class EventedTokenizer {
 
     selfClosingStartTag() {
       let char = this.peek();
+      this.selfClosingBuffer = false;
 
       if (char === '>') {
+        this.selfClosingBuffer = true;
         this.consume();
         this.delegate.markTagAsSelfClosing();
         this.delegate.finishTag();

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -216,10 +216,20 @@ QUnit.test('A newline immediately following a <PRE> tag is stripped', function(a
   assert.deepEqual(tokens, [startTag('PRE'), chars('hello'), endTag('PRE')]);
 });
 
+QUnit.test('A newline immediately following a <pre/> tag is not stripped', function(assert) {
+  let tokens = tokenize("<pre/>\n");
+  assert.deepEqual(tokens, [startTag('pre', [], true), chars('\n')]);
+});
+
 // https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
 QUnit.test('A newline immediately following a <textarea> tag is stripped', function(assert) {
   let tokens = tokenize("<textarea>\nhello</textarea>");
   assert.deepEqual(tokens, [startTag('textarea'), chars('hello'), endTag('textarea')]);
+});
+
+QUnit.test('A newline immediately following a <textarea/> tag is not stripped', function(assert) {
+  let tokens = tokenize("<textarea/>\n");
+  assert.deepEqual(tokens, [startTag('textarea', [], true), chars('\n')]);
 });
 
 // https://html.spec.whatwg.org/multipage/semantics.html#the-title-element


### PR DESCRIPTION
While `\n` should be stripped from `<textarea>\n<textarea/>` ([according to the html spec](https://github.com/tildeio/simple-html-tokenizer/pull/59#issue-183923917)), it should be preserved in `<textarea/>\n`?

It would help fix https://github.com/prettier/prettier/issues/8504 and supersedes https://github.com/tildeio/simple-html-tokenizer/pull/84