### PR TITLE
Escape </script> in library JS code for embedding

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -120,7 +120,7 @@ export default class EventedTokenizer {
 
     return (tag === 'title' && this.input.substring(this.index, this.index + 8) !== '</title>') ||
       (tag === 'style' && this.input.substring(this.index, this.index + 8) !== '</style>') ||
-      (tag === 'script' && this.input.substring(this.index, this.index + 9) !== '</script>');
+      (tag === 'script' && this.input.substring(this.index, this.index + 9) !== '<\/script>');
   }
 
   states: { [k in TokenizerState]?: (this: EventedTokenizer) => void } = {


### PR DESCRIPTION
This single line of escaping was needed to be able to embed this string to any html inside <script> tags without having it as a separate js file. Even bundled/transpiled output would preserve the string thus this change was needed.

Otherwise browsers try to close the JS early as it encounters the `</script>` inside the code which breaks the page/html rendering.

Related stack overflow issue: https://stackoverflow.com/questions/22488830/script-within-a-javascript-string-in-a-script-tag