### PR TITLE
allow elements to start with non-alpha chars to align with js vars

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -170,7 +170,7 @@ export default class EventedTokenizer {
         this.transitionTo(TokenizerState.markupDeclarationOpen);
       } else if (char === '/') {
         this.transitionTo(TokenizerState.endTagOpen);
-      } else if (char === '@' || char === ':' || isAlpha(char)) {
+      } else if (!isSpace(char)) {
         this.transitionTo(TokenizerState.tagName);
         this.tagNameBuffer = '';
         this.delegate.beginStartTag();
@@ -671,7 +671,7 @@ export default class EventedTokenizer {
     endTagOpen() {
       let char = this.consume();
 
-      if (char === '@' || char === ':' || isAlpha(char)) {
+      if (!isSpace(char)) {
         this.transitionTo(TokenizerState.endTagName);
         this.tagNameBuffer = '';
         this.delegate.beginEndTag();

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -169,6 +169,32 @@ QUnit.test('A simple tag', function(assert) {
   assert.deepEqual(tokens, [startTag('div')]);
 });
 
+QUnit.test('A simple tag with leading non alpha chars', function(assert) {
+  let tokens = tokenize('<_div>');
+  assert.deepEqual(tokens, [startTag('_div')]);
+
+  tokens = tokenize('<$div>');
+  assert.deepEqual(tokens, [startTag('$div')]);
+
+  tokens = tokenize('<:div>');
+  assert.deepEqual(tokens, [startTag(':div')]);
+
+  tokens = tokenize('<@div>');
+  assert.deepEqual(tokens, [startTag('@div')]);
+
+  tokens = tokenize('<üdiv>');
+  assert.deepEqual(tokens, [startTag('üdiv')]);
+
+  tokens = tokenize('<€div>');
+  assert.deepEqual(tokens, [startTag('€div')]);
+
+  tokens = tokenize('<div😀>');
+  assert.deepEqual(tokens, [startTag('div😀')]);
+
+  tokens = tokenize('<di😀v>');
+  assert.deepEqual(tokens, [startTag('di😀v')]);
+});
+
 QUnit.test('A simple tag with trailing spaces', function(assert) {
   let tokens = tokenize('<div   \t\n>');
   assert.deepEqual(tokens, [startTag('div')]);
@@ -177,6 +203,32 @@ QUnit.test('A simple tag with trailing spaces', function(assert) {
 QUnit.test('A simple closing tag', function(assert) {
   let tokens = tokenize('</div>');
   assert.deepEqual(tokens, [endTag('div')]);
+});
+
+QUnit.test('A simple closing tag with leading non alpha chars', function(assert) {
+  let tokens = tokenize('</_div>');
+  assert.deepEqual(tokens, [endTag('_div')]);
+
+  tokens = tokenize('</$div>');
+  assert.deepEqual(tokens, [endTag('$div')]);
+
+  tokens = tokenize('</:div>');
+  assert.deepEqual(tokens, [endTag(':div')]);
+
+  tokens = tokenize('</@div>');
+  assert.deepEqual(tokens, [endTag('@div')]);
+
+  tokens = tokenize('</üdiv>');
+  assert.deepEqual(tokens, [endTag('üdiv')]);
+
+  tokens = tokenize('</€div>');
+  assert.deepEqual(tokens, [endTag('€div')]);
+
+  tokens = tokenize('</di😀v>');
+  assert.deepEqual(tokens, [endTag('di😀v')]);
+
+  tokens = tokenize('</div😀>');
+  assert.deepEqual(tokens, [endTag('div😀')]);
 });
 
 QUnit.test('A simple closing tag with trailing spaces', function(assert) {


### PR DESCRIPTION
because with gjs we can reference variables that start with underscore